### PR TITLE
Fix Typo for TestCreateTransfer

### DIFF
--- a/db/sqlc/transfer_test.go
+++ b/db/sqlc/transfer_test.go
@@ -27,7 +27,7 @@ func createRandomTransfer(t *testing.T, firstAccount, secondAccount Account) Tra
 	return transfer
 }
 
-func TestCreateTransfert(t *testing.T) {
+func TestCreateTransfer(t *testing.T) {
 	firstAccount := createRandomAccount(t)
 	secondAccount := createRandomAccount(t)
 	createRandomTransfer(t, firstAccount, secondAccount)


### PR DESCRIPTION
FFix Typo from "TestCreateTransfert" to "TestCreateTransfer"